### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
   agent {
-    label 'docker'
+    label 'docker&&linux'
   }
 
   options {


### PR DESCRIPTION
Hopefully, we will have Windows docker agents soon, so specify this requires docker and linux