### PR TITLE
Enable release-drafter on jenkins-infra/openvpn

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,2 @@
+# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: jenkins-infra/.github


### PR DESCRIPTION
The purpose of this is to build docker images using a well identified release version.